### PR TITLE
ワークフロー改善: タグ時のリリース作成を無効化とテストをPR限定に

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -58,17 +58,3 @@ jobs:
           # Push tag
           git push origin "$new_version"
 
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.increment-version.outputs.new_version }}
-          release_name: Release ${{ steps.increment-version.outputs.new_version }}
-          body: |
-            Auto-generated release for ${{ steps.increment-version.outputs.new_version }}
-
-            Changes in this release:
-            - Automatic patch version increment
-          draft: false
-          prerelease: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tox:


### PR DESCRIPTION
## Summary
- auto-tag.ymlからリリース作成機能を削除
- test.yamlをPRでのみ実行するように修正

## Changes
- `auto-tag.yml`: Create Releaseステップを削除し、タグ作成のみに簡素化
- `test.yaml`: `on: [push, pull_request]` から `on: [pull_request]` に変更

## Test plan
- [ ] PRでテストが実行されることを確認
- [ ] mainマージ後にタグのみが作成されリリースが作成されないことを確認